### PR TITLE
typo

### DIFF
--- a/tema-2/README.md
+++ b/tema-2/README.md
@@ -754,7 +754,7 @@ Indiferent de ordinea din lista de inițializare, ordinea inițializărilor este
 
 Dacă inversăm ordinea din lista de inițializare:
 ```c++
-    curs_obligatoriu(const curs_obligatoriu& other) :  st(other.st), curs(other) {
+    curs_obligatoriu(const curs_obligatoriu& other) : st(other.st), curs(other) {
         std::cout << "cc curs_obligatoriu: " << st << "\n";
     }
 ```


### PR DESCRIPTION
erau doua spatii in loc de unul